### PR TITLE
Changed ci data frame column 'covariateId' to 'covariate' when confid…

### DIFF
--- a/R/ModelFitting.R
+++ b/R/ModelFitting.R
@@ -138,7 +138,7 @@ fitSccsModel <- function(sccsEraData,
           result
         }, error = function(e) {
           missing(e)  # suppresses R CMD check note
-          data.frame(covariateId = 0, logLb95 = 0, logUb95 = 0)
+          data.frame(covariate = 0, logLb95 = 0, logUb95 = 0)
         })
         names(ci)[names(ci) == "2.5 %"] <- "logLb95"
         names(ci)[names(ci) == "97.5 %"] <- "logUb95"


### PR DESCRIPTION
…ence interval cannot be generated.

Tested on exposure-outcome pair in which the CI cannot be computed, so the empty ci data frame needs to be created with the 'covariate' column, otherwise merge operation with estimates data frame fails.