### PR TITLE
Attempting to handle case when Cyclops model fit returns all `NA` estimates

### DIFF
--- a/R/ModelFitting.R
+++ b/R/ModelFitting.R
@@ -168,9 +168,10 @@ fitSccsModel <- function(sccsIntervalData,
       priorVariance <- 0
       status <- fit
     } else {
-      if (!is.null(profileGrid) || !is.null(profileBounds)) {
+      if ((!is.null(profileGrid) || !is.null(profileBounds)) && fit$return_flag != "ILLCONDITIONED") {
         covariateIds <- intersect(needProfile, as.numeric(Cyclops::getCovariateIds(cyclopsData)))
         getLikelihoodProfile <- function(covariateId) {
+          if (all(fit$estimates))
           logLikelihoodProfile <- Cyclops::getCyclopsProfileLogLikelihood(
             object = fit,
             parm = covariateId,

--- a/R/ModelFitting.R
+++ b/R/ModelFitting.R
@@ -171,7 +171,6 @@ fitSccsModel <- function(sccsIntervalData,
       if ((!is.null(profileGrid) || !is.null(profileBounds)) && fit$return_flag != "ILLCONDITIONED") {
         covariateIds <- intersect(needProfile, as.numeric(Cyclops::getCovariateIds(cyclopsData)))
         getLikelihoodProfile <- function(covariateId) {
-          if (all(fit$estimates))
           logLikelihoodProfile <- Cyclops::getCyclopsProfileLogLikelihood(
             object = fit,
             parm = covariateId,


### PR DESCRIPTION
I'm not sure if this patch is acceptable but the edge-case here is the following:

```r
    fit <- tryCatch(
      {
        Cyclops::fitCyclopsModel(cyclopsData, prior = prior, control = control)
      },
      error = function(e) {
        e$message
      }
    )
```

The `fit$estimates$estimate_value` (not sure if my variable names are 100% right) are all `NA` which then causes problems downstream when attempting to call `Cyclops::getCyclopsProfileLogLikelihood`, specifically [here](https://github.com/OHDSI/Cyclops/blob/5b1f4d68a1bb14896cd309c0b74d6e33d54a30a4/R/ModelFit.R#L945) since the with the error "missing value where TRUE/FALSE needed". 

I believe that this is due to the model being ill-conditioned and so I've added a check for the `fit$return_flag` to skip the log likelihood in this case.