### PR TITLE
Rounding min age in days to avoid non-integer days observed

### DIFF
--- a/R/StudyPopulation.R
+++ b/R/StudyPopulation.R
@@ -116,7 +116,7 @@ createStudyPopulation <- function(sccsData,
   if (!is.null(createStudyPopulationArgs$minAge) || !is.null(createStudyPopulationArgs$maxAge)) {
     labels <- c()
     if (!is.null(createStudyPopulationArgs$minAge) && nrow(cases) > 0) {
-      minAgeInDays <- createStudyPopulationArgs$minAge * 365.25
+      minAgeInDays <- round(createStudyPopulationArgs$minAge * 365.25)
       cases <- cases |>
         mutate(startAge = .data$ageAtObsStart + .data$startDay ,
                endAge = .data$ageAtObsStart + .data$endDay) |>


### PR DESCRIPTION
Applying fix from 2debad491716d422316344ffcf3ff718b6661995 for v6.

